### PR TITLE
Issue #3: Impossible to set empty prefix.

### DIFF
--- a/GoogleCloudStorageAdapter.php
+++ b/GoogleCloudStorageAdapter.php
@@ -233,8 +233,11 @@ class GoogleCloudStorageAdapter implements FilesystemAdapter
     public function listContents(string $path, bool $deep): iterable
     {
         $prefixedPath = $this->prefixer->prefixPath($path);
-        $options = ['prefix' => rtrim($prefixedPath, '/') . '/'];
-        $prefixes = [];
+        $prefixes = $options = [];
+
+        if (! empty($prefixedPath)) {
+            $options = ['prefix' => sprintf('%s/', rtrim($prefixedPath, '/'))];
+        }
 
         if ($deep === false) {
             $options['delimiter'] = '/';


### PR DESCRIPTION
### Context

Please have a look at issue #3.

### Proposed solution.

Solution proposed is to not automatically set **prefix** option when listing content. This option is only set when a prefix exists.