### PR TITLE
Issue #2: Upload with metadata

### DIFF
--- a/GoogleCloudStorageAdapter.php
+++ b/GoogleCloudStorageAdapter.php
@@ -79,6 +79,10 @@ class GoogleCloudStorageAdapter implements FilesystemAdapter
         $prefixedPath = $this->prefixer->prefixPath($path);
         $options = ['name' => $prefixedPath];
 
+        if ($metadata = $config->get('metadata')) {
+            $options['metadata'] = $metadata;
+        }
+
         $visibility = $config->get(Config::OPTION_VISIBILITY, $this->defaultVisibility);
         $predefinedAcl = $this->visibilityHandler->visibilityToPredefinedAcl($visibility);
 


### PR DESCRIPTION
### Context
See issue #2
When metadata is passed to the upload we should forward them to the Google Client.

```
        'cloud' => [
            'driver'        => 'gcs',
            'bucket'        => env('GOOGLE_CLOUD_STORAGE_BUCKET'),
            'metadata'      => ['cacheControl' => 'no-store'], // This wasnt working before
        ],
```

> This should be merged to both v2 and v3